### PR TITLE
Support users who party for more then 1 iteration of music.

### DIFF
--- a/_src/_includes/header.html
+++ b/_src/_includes/header.html
@@ -17,6 +17,6 @@
     </nav>
     <div class="header__actions">
         <button class="button js-party-button">Party 🎉</button>
-        <audio class="js-party-music" src="/assets/sounds/sandstorm.mp3" preload="none"></audio>
+        <audio loop class="js-party-music" src="/assets/sounds/sandstorm.mp3" preload="none"></audio>
     </div>
 </header>


### PR DESCRIPTION
This change fixes the problem stated in my [issue](https://github.com/rowbot-weisguy/rowbot-weisguy.github.io/issues/2). I believe rowbot-weisguy.github.io has a wide fan base of devote users to party mode. 

While some of them have passed their prime and will be satisfied with the currently supplied 55 seconds of party, others of us have been gifted with longer stamina.

I think party mode supplying continuous music is better for the community.

As a man who thrives on collaboration and being a team player, I'm open to further suggestions for refactoring/testing/modifying this change. Maybe we could create a seperate npm module for party music so this unfortunate issue does not arise again.

Thank you for your consideration. The floor is now open for debate :metal: ❤️ .